### PR TITLE
fix: make markdownlint glob pattern cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "start": "node server.js",
     "lint": "npm run lint:js && npm run lint:css && npm run lint:html && npm run lint:md",
     "lint:js": "eslint .",
-    "lint:css": "stylelint '**/*.css' || echo 'No CSS files found'",
-    "lint:html": "htmlhint '**/*.html'",
-    "lint:md": "markdownlint '**/*.md'",
+    "lint:css": "stylelint \"**/*.css\" || echo 'No CSS files found'",
+    "lint:html": "htmlhint \"**/*.html\"",
+    "lint:md": "markdownlint \"**/*.md\"",
     "docs": "jsdoc -d docs .",
     "test": "echo 'No tests specified'"
   },


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed the MarkdownLint script so that it runs correctly on both Windows and macOS.
Replaced single quotes in the glob pattern with double quotes to ensure cross-platform compatibility when expanding **/*.md during linting.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Pre-Submission Checklist

- [x] All tests pass locally
- [x] Code follows naming conventions
- [x] Documentation updated if needed
- [x] No console.log or debug statements
- [x] Security best practices followed & No API keys provided
- [x] Minimum 80% code coverage maintained

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] End-to-end tests added/updated (if applicable)

## Related Issues

Closes #2 
